### PR TITLE
Simplify wallet linking.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@helium/proto-ble": "^4.0.0",
     "@helium/react-native-sdk": "^2.1.0",
     "@helium/transactions": "^4.7.5",
-    "@helium/wallet-link": "^4.8.3",
+    "@helium/wallet-link": "^4.10.1",
     "@metaplex-foundation/mpl-bubblegum": "^0.6.2",
     "@pythnetwork/client": "^2.11.0",
     "@react-native-community/blur": "^3.6.0",

--- a/src/features/onboarding/welcome/WelcomeScreen.tsx
+++ b/src/features/onboarding/welcome/WelcomeScreen.tsx
@@ -10,11 +10,9 @@ import Box from '../../../components/Box'
 import TextTransform from '../../../components/TextTransform'
 import SafeAreaBox from '../../../components/SafeAreaBox'
 import TouchableOpacityBox from '../../../components/TouchableOpacityBox'
-import useDelegateApps from '../../../utils/useDelegateApps'
 
 const WelcomeScreen = () => {
   const { t } = useTranslation()
-  const { walletApp } = useDelegateApps()
   const navigation = useNavigation<OnboardingNavigationProp>()
 
   const createAccount = useCallback(
@@ -25,7 +23,6 @@ const WelcomeScreen = () => {
   const importAccount = useCallback(() => {
     try {
       const url = createWalletLinkUrl({
-        universalLink: walletApp?.universalLink,
         requestAppId: getBundleId(),
         callbackUrl: 'makerappscheme://',
         appName: 'Maker App',
@@ -36,7 +33,7 @@ const WelcomeScreen = () => {
       // eslint-disable-next-line no-console
       console.error(error)
     }
-  }, [walletApp?.universalLink])
+  }, [])
 
   return (
     <SafeAreaBox

--- a/src/features/transferHotspot/TransferHotspot.tsx
+++ b/src/features/transferHotspot/TransferHotspot.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react'
 import { useOnboarding } from '@helium/react-native-sdk'
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native'
-import { ActivityIndicator, Linking, Platform } from 'react-native'
+import { ActivityIndicator, Linking } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import {
   createUpdateHotspotUrl,
@@ -48,7 +48,6 @@ const TransferHotspot = () => {
       })
 
       const url = createUpdateHotspotUrl({
-        platform: Platform.OS,
         token,
         solanaTransactions: solanaTransactions?.join(','),
       })

--- a/src/utils/useCheckWalletLink.ts
+++ b/src/utils/useCheckWalletLink.ts
@@ -1,4 +1,8 @@
-import { parseWalletLinkToken, createWalletLinkUrl } from '@helium/wallet-link'
+import {
+  parseWalletLinkToken,
+  createWalletLinkUrl,
+  HELIUM_HOTSPOT_APP,
+} from '@helium/wallet-link'
 import { useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Alert, Linking, Platform } from 'react-native'
@@ -10,15 +14,13 @@ import useDelegateApps from './useDelegateApps'
 const useCheckWalletLink = () => {
   const { t } = useTranslation()
   const { walletLinkToken } = useSelector((state: RootState) => state.app)
-  const { hotspotApp, walletApp } = useDelegateApps()
+  const { walletApp } = useDelegateApps()
 
   const hotspotAppId = useMemo(() => {
-    if (!hotspotApp) return
-
     return Platform.OS === 'ios'
-      ? hotspotApp.iosBundleId
-      : hotspotApp.androidPackage
-  }, [hotspotApp])
+      ? HELIUM_HOTSPOT_APP.iosBundleId
+      : HELIUM_HOTSPOT_APP.androidPackage
+  }, [])
 
   const showAlert = useCallback(() => {
     if (!walletApp) return
@@ -30,7 +32,6 @@ const useCheckWalletLink = () => {
         text: t('wallet.checkLink.link'),
         onPress: () => {
           const url = createWalletLinkUrl({
-            universalLink: walletApp.universalLink,
             requestAppId: getBundleId(),
             callbackUrl: 'makerappscheme://',
             appName: 'Maker App',

--- a/src/utils/useDelegateApps.ts
+++ b/src/utils/useDelegateApps.ts
@@ -1,32 +1,20 @@
-import { DELEGATE_APPS } from '@helium/wallet-link'
-import { useCallback, useMemo } from 'react'
+import { HELIUM_WALLET_APP } from '@helium/wallet-link'
+import { useCallback } from 'react'
 import { Linking, Platform } from 'react-native'
 import { locale } from './i18n'
 
 const useDelegateApps = () => {
-  const hotspotApp = useMemo(
-    () => DELEGATE_APPS.find((app) => app.name === 'helium-hotspot'),
-
-    [],
-  )
-
-  const walletApp = useMemo(
-    () => DELEGATE_APPS.find((app) => app.name === 'helium-hnt-wallet'),
-    [],
-  )
-
   const downloadWalletApp = useCallback(() => {
-    if (!walletApp) return
     if (Platform.OS === 'android') {
-      Linking.openURL(`market://details?id=${walletApp.androidPackage}`)
+      Linking.openURL(`market://details?id=${HELIUM_WALLET_APP.androidPackage}`)
     } else if (Platform.OS === 'ios') {
       Linking.openURL(
-        `https://apps.apple.com/${locale}/app/${walletApp.name}/id${walletApp.appStoreId}`,
+        `https://apps.apple.com/${locale}/app/${HELIUM_WALLET_APP.name}/id${HELIUM_WALLET_APP.appStoreId}`,
       )
     }
-  }, [walletApp])
+  }, [])
 
-  return { walletApp, hotspotApp, downloadWalletApp }
+  return { walletApp: HELIUM_WALLET_APP, downloadWalletApp }
 }
 
 export default useDelegateApps

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,7 +1791,18 @@
     borsh "^0.7.0"
     bs58 "^5.0.0"
 
-"@helium/transactions@^4.11.1", "@helium/transactions@^4.7.5":
+"@helium/transactions@^4.10.1":
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/@helium/transactions/-/transactions-4.10.1.tgz#fb0c6379f797da2470120e7c0558ff893647c1bd"
+  integrity sha512-L0Mo/zG3HF7iTtvdAxTDtnQHZRtrnNPdq7GJq2spyB9HmOtdqbbOGip5KhnkSWzCVBTwCpYFkUlUvblGYqNVzg==
+  dependencies:
+    "@helium/address" "^4.8.1"
+    "@helium/proto" "^1.6.0"
+    "@types/libsodium-wrappers" "^0.7.8"
+    long "^4.0.0"
+    path "^0.12.7"
+
+"@helium/transactions@^4.7.5":
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/@helium/transactions/-/transactions-4.11.1.tgz#38c48d0c2c395ce1e0a78fd57510c09d958c24e8"
   integrity sha512-uL6OKo5o8AKn7oOuuW6/T7MSwPikbYU2HsSDu2O7ZhnGiyzKcKXQMkIHSBuFKz9KT+DKVpVSwjeLXr4a6/D/eQ==
@@ -1841,13 +1852,13 @@
     bn.js "^5.2.0"
     bs58 "^4.0.1"
 
-"@helium/wallet-link@^4.8.3":
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/@helium/wallet-link/-/wallet-link-4.11.1.tgz#9e0b22cfe83080f8ca5544eb52f8854549af4e35"
-  integrity sha512-bumli6m4Me2a/0XioJiR8yrcRrVll1KujNuaR2qkeuAdfV1hx51k/rR+clIKUrHkdn+OFyMvd1odytXkMVnO9g==
+"@helium/wallet-link@^4.10.1":
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/@helium/wallet-link/-/wallet-link-4.10.1.tgz#711340da93686186975aaa75a922023390bd5e93"
+  integrity sha512-L2KhPipJi7/TUG+dcCqYwUDVWZM4XxScqYgF7dqeHMgEYiX653SkOx5tpk3AvF8pFPnV58W5oEMDfn6LKg0AiA==
   dependencies:
-    "@helium/address" "^4.11.1"
-    "@helium/transactions" "^4.11.1"
+    "@helium/address" "^4.8.1"
+    "@helium/transactions" "^4.10.1"
     date-fns "^2.28.0"
     query-string "^7.1.1"
 


### PR DESCRIPTION
Now that the Helium Hotspot app is no longer supported, wallet linking can be simplified.